### PR TITLE
Forward compatibility with stable EventLoop 1.0 and 0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,9 +15,9 @@
     },
     "require": {
         "php": ">=5.3",
-        "react/event-loop": "~0.4.0|~0.3.0",
-        "react/promise": "~2.0|~1.0",
-        "clue/multicast-react": "~0.2.0"
+        "clue/multicast-react": "^1.0 || ^0.2",
+        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/promise": "^2.0 || ^1.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^6.0 || ^5.7 || ^4.8.35"

--- a/src/Client.php
+++ b/src/Client.php
@@ -40,9 +40,10 @@ class Client
             $socket->close();
         });
 
-        $deferred = new Deferred(function () use ($socket, &$timer) {
+        $loop = $this->loop;
+        $deferred = new Deferred(function () use ($socket, &$timer, $loop) {
             // canceling resulting promise cancels timer and closes socket
-            $timer->cancel();
+            $loop->cancelTimer($timer);
             $socket->close();
             throw new RuntimeException('Cancelled');
         });


### PR DESCRIPTION
Builds on top of clue/reactphp-multicast#11
Refs https://github.com/clue/reactphp-mdns/pull/11
Refs reactphp/event-loop#102 and reactphp/event-loop#138