### PR TITLE
Simplify usage by supporting new default loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,7 @@ as defined in [RFC 6763](http://tools.ietf.org/html/rfc6763).
 Once [installed](#install), you can use the following code to search all available UPnP devices in your network:
 
 ```php
-$loop = React\EventLoop\Factory::create();
-$client = new Client($loop);
+$client = new Clue\React\Ssdp\Client();
 
 $client->search()->then(
     function () {
@@ -47,8 +46,6 @@ $client->search()->then(
         echo PHP_EOL;
     }
 );
-
-$loop->run();
 ```
 
 See also the [examples](examples).

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "require": {
         "php": ">=5.3",
         "clue/multicast-react": "^1.0 || ^0.2",
-        "react/event-loop": "^1.0 || ^0.5 || ^0.4 || ^0.3",
+        "react/event-loop": "^1.2",
         "react/promise": "^2.0 || ^1.0"
     },
     "require-dev": {

--- a/examples/demo.php
+++ b/examples/demo.php
@@ -4,8 +4,7 @@ use Clue\React\Ssdp\Client;
 
 require __DIR__ . '/../vendor/autoload.php';
 
-$loop = React\EventLoop\Factory::create();
-$client = new Client($loop);
+$client = new Client();
 
 $client->search()->then(
     function () {
@@ -20,5 +19,3 @@ $client->search()->then(
         echo PHP_EOL;
     }
 );
-
-$loop->run();

--- a/src/Client.php
+++ b/src/Client.php
@@ -2,8 +2,9 @@
 
 namespace Clue\React\Ssdp;
 
-use React\EventLoop\LoopInterface;
 use Clue\React\Multicast\Factory as MulticastFactory;
+use React\EventLoop\Loop;
+use React\EventLoop\LoopInterface;
 use React\Promise\Deferred;
 use RuntimeException;
 
@@ -11,16 +12,26 @@ class Client
 {
     const ADDRESS = '239.255.255.250:1900';
 
+    /** @var LoopInterface */
     private $loop;
+
+    /** @var MulticastFactory */
     private $multicast;
 
-    public function __construct(LoopInterface $loop, MulticastFactory $multicast = null)
+    /**
+     * This class takes an optional `LoopInterface|null $loop` parameter that can be used to
+     * pass the event loop instance to use for this object. You can use a `null` value
+     * here in order to use the [default loop](https://github.com/reactphp/event-loop#loop).
+     * This value SHOULD NOT be given unless you're sure you want to explicitly use a
+     * given event loop instance.
+     *
+     * @param ?LoopInterface $loop
+     * @param ?MulticastFactory $multicast
+     */
+    public function __construct(LoopInterface $loop = null, MulticastFactory $multicast = null)
     {
-        if ($multicast === null) {
-            $multicast = new MulticastFactory($loop);
-        }
-        $this->loop = $loop;
-        $this->multicast = $multicast;
+        $this->loop = $loop ?: Loop::get();
+        $this->multicast = $multicast ?: new MulticastFactory($this->loop);
     }
 
     public function search($searchTarget = 'ssdp:all', $mx = 2)

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -3,10 +3,21 @@
 namespace Clue\Tests\React\Ssdp;
 
 use Clue\React\Ssdp\Client;
-use React\EventLoop\Factory;
+use React\EventLoop\Loop;
 
 class ClientTest extends TestCase
 {
+    public function testConstructWithoutLoopAssignsLoopAutomatically()
+    {
+        $client = new Client();
+
+        $ref = new \ReflectionProperty($client, 'loop');
+        $ref->setAccessible(true);
+        $loop = $ref->getValue($client);
+
+        $this->assertInstanceOf('React\EventLoop\LoopInterface', $loop);
+    }
+
     /**
      * @doesNotPerformAssertions
      */
@@ -52,12 +63,11 @@ class ClientTest extends TestCase
 
     public function testSearchTimeout()
     {
-        $loop = Factory::create();
-        $client = new Client($loop);
+        $client = new Client();
 
         $promise = $client->search('ssdp:all', 0.01);
 
-        $loop->run();
+        Loop::run();
 
         $promise->then($this->expectCallableOnce(), $this->expectCallableNever(), $this->expectCallableNever());
     }


### PR DESCRIPTION
This changeset simplifies usage by supporting the new [default loop](https://github.com/reactphp/event-loop#loop).

```php
// old (still supported)
$client = new Clue\React\Ssdp\Client($loop);

// new (using default loop)
$factory = new Clue\React\Ssdp\Client();
```
Builds on top of reactphp/event-loop#226, reactphp/event-loop#229 and reactphp/event-loop#232