### PR TITLE
Run tests on PHP 8.4 and update test environment + fix nullable type deprecations

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php:
+          - 8.4
           - 8.3
           - 8.2
           - 8.1
@@ -38,7 +39,7 @@ jobs:
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4

--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     },
     "require": {
         "php": ">=5.3",
-        "clue/multicast-react": "^1.0 || ^0.2",
+        "clue/multicast-react": "1.x-dev#f1bd5df0309b9f8b3486b09bf37aedfb042addb6",
         "react/event-loop": "^1.2",
-        "react/promise": "^2.0 || ^1.0"
+        "react/promise": "^3.2 || ^2.7 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -71,4 +71,32 @@ class ClientTest extends TestCase
 
         $promise->then($this->expectCallableOnce(), $this->expectCallableNever(), $this->expectCallableNever());
     }
+
+    public function testCtorThrowsForInvalidLoop()
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException('InvalidArgumentException');
+            $this->expectExceptionMessage('Argument #1 ($loop) expected null|React\EventLoop\LoopInterface');
+        } else {
+            // legacy PHPUnit
+            $this->setExpectedException('InvalidArgumentException', 'Argument #1 ($loop) expected null|React\EventLoop\LoopInterface');
+        }
+
+        new Client('loop');
+    }
+
+    public function testCtorThrowsForInvalidMulticast()
+    {
+        if (method_exists($this, 'expectException')) {
+            // PHPUnit 5.2+
+            $this->expectException('InvalidArgumentException');
+            $this->expectExceptionMessage('Argument #2 ($multicast) expected null|Clue\React\Multicast\Factory');
+        } else {
+            // legacy PHPUnit
+            $this->setExpectedException('InvalidArgumentException', 'Argument #2 ($multicast) expected null|Clue\React\Multicast\Factory');
+        }
+
+        new Client(null, 'multicast');
+    }
 }


### PR DESCRIPTION
The main goal was to add PHP 8.4 support and upgrade to ubuntu-24.04. To achieve this, I had to fix PHP 8.4's implicitly nullable parameter deprecation warnings. 
Since the project needs to support PHP 5.3+ and nullable types are only available from PHP 7.1+, I removed the type hints and implemented manual if-statements for type checking that work with all PHP versions and added tests to validate this behavior. 
Additionally, updates to react/promise and clue/multicast-react dependencies were required, as well as adjustments to the search method using `array()` instead of `[]` syntax and modified message collection to maintain PHP 5.3 compatibility.

Builds on top of #16 and https://github.com/reactphp/promise/pull/260.