### PR TITLE
Improve PHP 8.4+ support by avoiding implicitly nullable types

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -28,8 +28,14 @@ class Client
      * @param ?LoopInterface $loop
      * @param ?MulticastFactory $multicast
      */
-    public function __construct(LoopInterface $loop = null, MulticastFactory $multicast = null)
+    public function __construct($loop = null, $multicast = null)
     {
+    	if ($loop !== null && !$loop instanceof LoopInterface) { // manual type check to support legacy PHP < 7.1
+    		throw new \InvalidArgumentException('Argument #1 ($loop) expected null|React\EventLoop\LoopInterface');
+    	}
+    	if ($multicast !== null && !$multicast instanceof MulticastFactory) { // manual type check to support legacy PHP < 7.1
+    		throw new \InvalidArgumentException('Argument #2 ($multicast) expected null|Clue\React\Multicast\Factory');
+    	}
         $this->loop = $loop ?: Loop::get();
         $this->multicast = $multicast ?: new MulticastFactory($this->loop);
     }

--- a/tests/ClientTest.php
+++ b/tests/ClientTest.php
@@ -71,4 +71,32 @@ class ClientTest extends TestCase
 
         $promise->then($this->expectCallableOnce(), $this->expectCallableNever(), $this->expectCallableNever());
     }
+
+    public function testCtorThrowsForInvalidLoop()
+    {
+    	if (method_exists($this, 'expectException')) {
+    		// PHPUnit 5.2+
+    		$this->expectException('InvalidArgumentException');
+    		$this->expectExceptionMessage('Argument #1 ($loop) expected null|React\EventLoop\LoopInterface');
+    	} else {
+    		// legacy PHPUnit
+    		$this->setExpectedException('InvalidArgumentException', 'Argument #1 ($loop) expected null|React\EventLoop\LoopInterface');
+    	}
+
+    	new Client('loop');
+    }
+
+    public function testCtorThrowsForInvalidMulticast()
+    {
+    	if (method_exists($this, 'expectException')) {
+    		// PHPUnit 5.2+
+    		$this->expectException('InvalidArgumentException');
+    		$this->expectExceptionMessage('Argument #2 ($multicast) expected null|Clue\React\Multicast\Factory');
+    	} else {
+    		// legacy PHPUnit
+    		$this->setExpectedException('InvalidArgumentException', 'Argument #2 ($multicast) expected null|Clue\React\Multicast\Factory');
+    	}
+
+    	new Client(null, 'multicast');
+    }
 }


### PR DESCRIPTION
This changeset improves PHP 8.4+ support by avoiding implicitly nullable types as discussed in https://github.com/reactphp/promise/pull/260. The same idea applies, but v1 requires manual type checks to support legacy PHP versions as the nullable type syntax requires PHP 7.1+ otherwise.

Builds on top of #15, #16, https://github.com/reactphp/promise/pull/260 and others.