### PR TITLE
Update dependencies and improve search method

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,9 +22,9 @@
     },
     "require": {
         "php": ">=5.3",
-        "clue/multicast-react": "^1.0 || ^0.2",
+        "clue/multicast-react": "1.x-dev#f1bd5df0309b9f8b3486b09bf37aedfb042addb6",
         "react/event-loop": "^1.2",
-        "react/promise": "^2.0 || ^1.0"
+        "react/promise": "^3.2 || ^2.7 || ^1.2.1"
     },
     "require-dev": {
         "phpunit/phpunit": "^9.6 || ^5.7 || ^4.8.36"


### PR DESCRIPTION
Update dependencies to support PHP 5.3 and react/promise v3.2+

- Upgrade react/promise dependency to include v3.2+, adapting to new resolve() API that requires an argument.
- Update clue/multicast-react:
    - The latest code includes essential fixes for compatibility with updated react/promise APIs and PHP 8+,
    - This ensures multicast functionality works correctly with new dependencies and PHP versions.
- Modify search() method to accumulate all incoming messages in array() before resolving the promise, ensuring proper integration with the updated promise API and maintaining PHP 5.3 compatibility.
- Use explicit array() syntax instead of [] throughout the code for PHP 5.3 support.
