### PR TITLE
Run tests on PHP 8.4 and update test environment

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,11 @@ on:
 jobs:
   PHPUnit:
     name: PHPUnit (PHP ${{ matrix.php }})
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php:
+          - 8.4
           - 8.3
           - 8.2
           - 8.1
@@ -38,7 +39,7 @@ jobs:
 
   PHPUnit-hhvm:
     name: PHPUnit (HHVM)
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     continue-on-error: true
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
- Add PHP 8.4 to CI test matrix
- Upgrade CI runners from ubuntu-22.04 to ubuntu-24.04

Builds on top of #16.

⚠️ **This PR can only be merged after PR #19 & #20 has been merged**, as it requires the PHP 8.4 compatibility fixes and dependency updates to pass successfully.

Resolves #18.